### PR TITLE
NoImportingEverythingWithFix

### DIFF
--- a/preview/elm.json
+++ b/preview/elm.json
@@ -8,21 +8,20 @@
     "dependencies": {
         "direct": {
             "elm/core": "1.0.5",
-            "elm/json": "1.1.3",
+            "elm/json": "1.1.4",
             "elm/project-metadata-utils": "1.0.2",
-            "jfmengels/elm-review": "2.13.0",
-            "stil4m/elm-syntax": "7.2.9"
+            "jfmengels/elm-review": "2.15.3",
+            "stil4m/elm-syntax": "7.3.9"
         },
         "indirect": {
             "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
             "elm/time": "1.0.0",
-            "elm/virtual-dom": "1.0.3",
-            "elm-community/list-extra": "8.7.0",
-            "elm-explorations/test": "2.1.1",
-            "miniBill/elm-unicode": "1.0.3",
+            "elm/virtual-dom": "1.0.4",
+            "elm-explorations/test": "2.2.0",
             "rtfeldman/elm-hex": "1.0.0",
             "stil4m/structured-writer": "1.0.3"
         }

--- a/preview/src/ReviewConfig.elm
+++ b/preview/src/ReviewConfig.elm
@@ -14,7 +14,7 @@ when inside the directory containing this file.
 import NoConfusingPrefixOperator
 import NoDeprecated
 import NoExposingEverything
-import NoImportingEverything
+import NoImportingEverythingWithFix as NoImportingEverything
 import NoMissingTypeAnnotation
 import NoMissingTypeAnnotationInLetIn
 import NoMissingTypeExpose

--- a/review/elm.json
+++ b/review/elm.json
@@ -8,17 +8,17 @@
     "dependencies": {
         "direct": {
             "elm/core": "1.0.5",
-            "elm/json": "1.1.3",
+            "elm/json": "1.1.4",
             "elm/project-metadata-utils": "1.0.2",
-            "jfmengels/elm-review": "2.13.0",
-            "jfmengels/elm-review-code-style": "1.1.4",
+            "jfmengels/elm-review": "2.15.3",
+            "jfmengels/elm-review-code-style": "1.2.0",
             "jfmengels/elm-review-cognitive-complexity": "1.0.3",
             "jfmengels/elm-review-debug": "1.0.8",
-            "jfmengels/elm-review-documentation": "2.0.3",
-            "jfmengels/elm-review-simplify": "2.0.29",
-            "jfmengels/elm-review-unused": "1.1.29",
+            "jfmengels/elm-review-documentation": "2.0.4",
+            "jfmengels/elm-review-simplify": "2.1.9",
+            "jfmengels/elm-review-unused": "1.2.4",
             "sparksp/elm-review-forbidden-words": "1.0.1",
-            "stil4m/elm-syntax": "7.2.9"
+            "stil4m/elm-syntax": "7.3.9"
         },
         "indirect": {
             "elm/bytes": "1.0.8",
@@ -27,10 +27,8 @@
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
             "elm/time": "1.0.0",
-            "elm/virtual-dom": "1.0.3",
-            "elm-community/list-extra": "8.7.0",
-            "elm-explorations/test": "2.1.1",
-            "miniBill/elm-unicode": "1.0.3",
+            "elm/virtual-dom": "1.0.4",
+            "elm-explorations/test": "2.2.0",
             "pzp1997/assoc-list": "1.0.0",
             "rtfeldman/elm-hex": "1.0.0",
             "stil4m/structured-writer": "1.0.3"

--- a/src/NoImportingEverythingWithFix.elm
+++ b/src/NoImportingEverythingWithFix.elm
@@ -1,0 +1,433 @@
+module NoImportingEverythingWithFix exposing (rule)
+
+{-| Rule to replace `exposing (..)` with explicit imports of what the module actually exposes.
+
+This rule extends the existing NoImportingEverything rule to provide automatic fixes
+by replacing `import Module exposing (..)` with `import Module exposing (explicit, list)`.
+
+@docs rule
+
+-}
+
+import Dict exposing (Dict)
+import Elm.Docs as Docs
+import Elm.Syntax.Declaration as Declaration
+import Elm.Syntax.Exposing as Exposing
+import Elm.Syntax.Import exposing (Import)
+import Elm.Syntax.Module as Module
+import Elm.Syntax.Node as Node exposing (Node)
+import Elm.Syntax.Range exposing (Range)
+import Review.Fix as Fix
+import Review.Project.Dependency as Dependency exposing (Dependency)
+import Review.Rule as Rule exposing (Error, Rule)
+import Set exposing (Set)
+
+
+{-| Reports imports using `exposing (..)` and provides automatic fixes to replace them with explicit imports.
+
+    config =
+        [ NoImportingEverythingWithFix.rule []
+        ]
+
+Teams often have an agreement on the list of imports from which it is okay to expose everything, so
+you can configure a list of exceptions.
+
+    config =
+        [ NoImportingEverythingWithFix.rule [ "Html", "Html.Attributes" ]
+        ]
+
+🔧 Running with `--fix` will automatically fix all the reported errors by replacing `(..)` with explicit imports.
+
+This rule analyzes external dependencies to get precise export information and also
+collects internal module exports as it processes each file.
+
+-}
+rule : List String -> Rule
+rule exceptions =
+    Rule.newProjectRuleSchema "NoImportingEverythingWithFix" (initialProjectContext exceptions)
+        |> Rule.withDependenciesProjectVisitor dependenciesVisitor
+        |> Rule.withModuleVisitor moduleVisitor
+        |> Rule.withModuleContextUsingContextCreator
+            { fromProjectToModule = fromProjectToModule
+            , fromModuleToProject = fromModuleToProject
+            , foldProjectContexts = foldProjectContexts
+            }
+        |> Rule.withFinalProjectEvaluation finalProjectEvaluation
+        |> Rule.providesFixesForProjectRule
+        |> Rule.fromProjectRuleSchema
+
+
+
+-- CONTEXT
+
+
+type alias ProjectContext =
+    { exceptions : Set String
+    , internalExports : Dict String (List String) -- Internal project modules: "Module.Name" -> ["export1", "export2"]
+    , externalExports : Dict String (List String) -- External packages: "Module.Name" -> ["export1", "export2"]
+    , importIssues : List ImportIssue -- Issues found during module processing
+    }
+
+
+type alias ImportIssue =
+    { moduleName : String
+    , importRange : Range
+    , moduleKey : Rule.ModuleKey
+    }
+
+
+type alias ModuleContext =
+    { exceptions : Set String
+    , internalExports : Dict String (List String)
+    , externalExports : Dict String (List String)
+    , currentModuleName : String
+    , currentModuleExports : List String -- Collect exports as we traverse the current module
+    , currentModuleExposesAll : Bool -- Track if current module uses exposing (..)
+    , importIssues : List ImportIssue -- Import issues found in this module
+    , moduleKey : Rule.ModuleKey -- Module key for error reporting
+    }
+
+
+initialProjectContext : List String -> ProjectContext
+initialProjectContext exceptions =
+    { exceptions = Set.fromList exceptions
+    , internalExports = Dict.empty
+    , externalExports = Dict.empty
+    , importIssues = []
+    }
+
+
+fromProjectToModule : Rule.ContextCreator ProjectContext ModuleContext
+fromProjectToModule =
+    Rule.initContextCreator
+        (\moduleKey projectContext ->
+            { exceptions = projectContext.exceptions
+            , internalExports = projectContext.internalExports
+            , externalExports = projectContext.externalExports
+            , currentModuleName = ""
+            , currentModuleExports = []
+            , currentModuleExposesAll = False
+            , importIssues = []
+            , moduleKey = moduleKey
+            }
+        )
+        |> Rule.withModuleKey
+
+
+fromModuleToProject : Rule.ContextCreator ModuleContext ProjectContext
+fromModuleToProject =
+    Rule.initContextCreator
+        (\moduleContext ->
+            let
+                -- If we collected exports for a module that exposes all, add them to internal exports
+                updatedInternalExports : Dict String (List String)
+                updatedInternalExports =
+                    if moduleContext.currentModuleExposesAll && not (List.isEmpty moduleContext.currentModuleExports) then
+                        Dict.insert moduleContext.currentModuleName moduleContext.currentModuleExports moduleContext.internalExports
+
+                    else
+                        moduleContext.internalExports
+            in
+            { exceptions = moduleContext.exceptions
+            , internalExports = updatedInternalExports
+            , externalExports = moduleContext.externalExports
+            , importIssues = moduleContext.importIssues
+            }
+        )
+
+
+foldProjectContexts : ProjectContext -> ProjectContext -> ProjectContext
+foldProjectContexts newContext previousContext =
+    { exceptions = newContext.exceptions
+    , internalExports = Dict.union newContext.internalExports previousContext.internalExports
+    , externalExports = Dict.union newContext.externalExports previousContext.externalExports
+    , importIssues = newContext.importIssues ++ previousContext.importIssues
+    }
+
+
+
+-- VISITORS
+
+
+dependenciesVisitor : Dict String Dependency -> ProjectContext -> ( List (Error { useErrorForModule : () }), ProjectContext )
+dependenciesVisitor dependencies context =
+    let
+        processedExports : Dict String (List String)
+        processedExports =
+            dependencies
+                |> Dict.toList
+                |> List.concatMap
+                    (\( _, dependency ) ->
+                        Dependency.modules dependency
+                            |> List.map (\moduleDoc -> ( moduleDoc.name, extractExportsFromDocsModule moduleDoc ))
+                    )
+                |> Dict.fromList
+    in
+    ( [], { context | externalExports = processedExports } )
+
+
+moduleVisitor : Rule.ModuleRuleSchema {} ModuleContext -> Rule.ModuleRuleSchema { hasAtLeastOneVisitor : () } ModuleContext
+moduleVisitor schema =
+    schema
+        |> Rule.withModuleDefinitionVisitor moduleDefinitionVisitor
+        |> Rule.withDeclarationListVisitor declarationListVisitor
+        |> Rule.withImportVisitor importVisitor
+
+
+moduleDefinitionVisitor : Node Module.Module -> ModuleContext -> ( List (Error {}), ModuleContext )
+moduleDefinitionVisitor node context =
+    let
+        moduleDefinition : Module.Module
+        moduleDefinition =
+            Node.value node
+
+        moduleName : String
+        moduleName =
+            moduleDefinition
+                |> Module.moduleName
+                |> String.join "."
+
+        ( moduleExports, exposesAll ) =
+            case Module.exposingList moduleDefinition of
+                Exposing.All _ ->
+                    -- Module exposes everything - we'll collect exports from declarations
+                    ( [], True )
+
+                Exposing.Explicit explicitExposes ->
+                    -- Module has explicit exports
+                    ( explicitExposes
+                        |> List.filterMap (Node.value >> extractExplicitExpose)
+                    , False
+                    )
+
+        updatedInternalExports : Dict String (List String)
+        updatedInternalExports =
+            if List.isEmpty moduleExports || exposesAll then
+                context.internalExports
+
+            else
+                Dict.insert moduleName moduleExports context.internalExports
+    in
+    ( []
+    , { context
+        | internalExports = updatedInternalExports
+        , currentModuleName = moduleName
+        , currentModuleExports = []
+        , currentModuleExposesAll = exposesAll
+      }
+    )
+
+
+declarationListVisitor : List (Node Declaration.Declaration) -> ModuleContext -> ( List (Error {}), ModuleContext )
+declarationListVisitor declarations context =
+    if not context.currentModuleExposesAll then
+        -- Only collect exports if module uses exposing (..)
+        ( [], context )
+
+    else
+        let
+            exports : List String
+            exports =
+                declarations
+                    |> List.filterMap (Node.value >> extractDeclarationName)
+        in
+        ( [], { context | currentModuleExports = exports } )
+
+
+importVisitor : Node Import -> ModuleContext -> ( List (Error {}), ModuleContext )
+importVisitor node context =
+    let
+        import_ : Import
+        import_ =
+            Node.value node
+
+        moduleName : String
+        moduleName =
+            import_.moduleName
+                |> Node.value
+                |> String.join "."
+
+        updatedContext : ModuleContext
+        updatedContext =
+            if Set.member moduleName context.exceptions then
+                context
+
+            else
+                case import_.exposingList |> Maybe.map Node.value of
+                    Just (Exposing.All range) ->
+                        let
+                            -- Calculate the range for the entire "(..)" including parentheses
+                            fullRange : { start : { row : Int, column : Int }, end : { row : Int, column : Int } }
+                            fullRange =
+                                { start = { row = range.start.row, column = range.start.column - 1 }
+                                , end = { row = range.end.row, column = range.end.column + 1 }
+                                }
+
+                            importIssue : { moduleName : String, importRange : { start : { row : Int, column : Int }, end : { row : Int, column : Int } }, moduleKey : Rule.ModuleKey }
+                            importIssue =
+                                { moduleName = moduleName
+                                , importRange = fullRange
+                                , moduleKey = context.moduleKey
+                                }
+                        in
+                        { context | importIssues = importIssue :: context.importIssues }
+
+                    _ ->
+                        context
+    in
+    ( [], updatedContext )
+
+
+finalProjectEvaluation : ProjectContext -> List (Error { useErrorForModule : () })
+finalProjectEvaluation context =
+    context.importIssues
+        |> List.map (generateErrorForImportIssue context)
+
+
+generateErrorForImportIssue : ProjectContext -> ImportIssue -> Error { useErrorForModule : () }
+generateErrorForImportIssue context issue =
+    case getModuleExportsFromContext issue.moduleName context of
+        Just exports ->
+            Rule.errorForModuleWithFix
+                issue.moduleKey
+                { message = "Prefer listing what you wish to import and/or using qualified imports"
+                , details = [ "When you import everything from a module it becomes harder to know where a function or a type comes from." ]
+                }
+                issue.importRange
+                [ Fix.replaceRangeBy issue.importRange ("(" ++ String.join ", " exports ++ ")") ]
+
+        Nothing ->
+            Rule.errorForModule
+                issue.moduleKey
+                { message = "Prefer listing what you wish to import and/or using qualified imports"
+                , details = [ "When you import everything from a module it becomes harder to know where a function or a type comes from." ]
+                }
+                issue.importRange
+
+
+
+-- HELPERS
+
+
+{-| Extract all exports from an Elm.Docs.Module.
+-}
+extractExportsFromDocsModule : Docs.Module -> List String
+extractExportsFromDocsModule docsModule =
+    let
+        aliases : List String
+        aliases =
+            docsModule.aliases
+                |> List.map .name
+
+        unions : List String
+        unions =
+            docsModule.unions
+                |> List.map
+                    (\union ->
+                        if List.isEmpty union.tags then
+                            -- Just the type name if no constructors
+                            union.name
+
+                        else
+                            -- Include all constructors with (..) syntax
+                            union.name ++ "(..)"
+                    )
+
+        values : List String
+        values =
+            docsModule.values
+                |> List.map .name
+
+        binops : List String
+        binops =
+            docsModule.binops
+                |> List.map (\binop -> "(" ++ binop.name ++ ")")
+    in
+    aliases
+        ++ unions
+        ++ values
+        ++ binops
+
+
+{-| Get the exports for a module from project context, checking both internal and external modules
+-}
+getModuleExportsFromContext : String -> ProjectContext -> Maybe (List String)
+getModuleExportsFromContext moduleName context =
+    -- First check internal modules
+    case Dict.get moduleName context.internalExports of
+        Just exports ->
+            Just exports
+
+        Nothing ->
+            -- Then check external modules
+            Dict.get moduleName context.externalExports
+
+
+{-| Extract explicit export from an exposing list item
+-}
+extractExplicitExpose : Exposing.TopLevelExpose -> Maybe String
+extractExplicitExpose expose =
+    case expose of
+        Exposing.InfixExpose operator ->
+            Just ("(" ++ operator ++ ")")
+
+        Exposing.FunctionExpose functionName ->
+            Just functionName
+
+        Exposing.TypeOrAliasExpose typeName ->
+            Just typeName
+
+        Exposing.TypeExpose typeExpose ->
+            let
+                typeName : String
+                typeName =
+                    typeExpose.name
+            in
+            case typeExpose.open of
+                Just _ ->
+                    -- Type with (..) - expose all constructors
+                    Just (typeName ++ "(..)")
+
+                Nothing ->
+                    -- Just the type name
+                    Just typeName
+
+
+{-| Extract the name from a declaration if it's exportable
+-}
+extractDeclarationName : Declaration.Declaration -> Maybe String
+extractDeclarationName declaration =
+    case declaration of
+        Declaration.FunctionDeclaration function ->
+            function.declaration
+                |> Node.value
+                |> .name
+                |> Node.value
+                |> Just
+
+        Declaration.AliasDeclaration alias ->
+            alias.name
+                |> Node.value
+                |> Just
+
+        Declaration.CustomTypeDeclaration customType ->
+            -- For custom types, include the type name with (..) to expose constructors
+            customType.name
+                |> Node.value
+                |> (\name -> name ++ "(..)")
+                |> Just
+
+        Declaration.PortDeclaration signature ->
+            signature.name
+                |> Node.value
+                |> Just
+
+        Declaration.InfixDeclaration infix ->
+            infix.operator
+                |> Node.value
+                |> (\op -> "(" ++ op ++ ")")
+                |> Just
+
+        Declaration.Destructuring _ _ ->
+            -- Destructuring patterns don't create exports
+            Nothing

--- a/tests/NoImportingEverythingWithFixTest.elm
+++ b/tests/NoImportingEverythingWithFixTest.elm
@@ -1,0 +1,323 @@
+module NoImportingEverythingWithFixTest exposing (all)
+
+import NoImportingEverythingWithFix exposing (rule)
+import Review.Project as Project exposing (Project)
+import Review.Test
+import Review.Test.Dependencies
+import Test exposing (Test, describe, test)
+
+
+all : Test
+all =
+    describe "NoImportingEverythingWithFix"
+        [ noErrorTests
+        , errorTests
+        , externalModuleFixTests
+        , internalModuleFixTests
+        , mixedScenarioTests
+        ]
+
+
+noErrorTests : Test
+noErrorTests =
+    describe "should not report an error"
+        [ test "when importing without exposing clause" <|
+            \() ->
+                """module A exposing (..)
+import Html
+import Html as H
+"""
+                    |> Review.Test.run (rule [])
+                    |> Review.Test.expectNoErrors
+        , test "when importing with explicit exposing list" <|
+            \() ->
+                """module A exposing (..)
+import Html exposing (div, text)
+import Html.Attributes exposing (class)
+"""
+                    |> Review.Test.run (rule [])
+                    |> Review.Test.expectNoErrors
+        , test "when importing with type constructors" <|
+            \() ->
+                """module A exposing (..)
+import Html exposing (Html(..), div)
+"""
+                    |> Review.Test.run (rule [])
+                    |> Review.Test.expectNoErrors
+        , test "when module is in exceptions list" <|
+            \() ->
+                """module A exposing (..)
+import Html exposing (..)
+import Html.Attributes exposing (..)
+"""
+                    |> Review.Test.run (rule [ "Html", "Html.Attributes" ])
+                    |> Review.Test.expectNoErrors
+        ]
+
+
+errorTests : Test
+errorTests =
+    describe "should report an error"
+        [ test "when importing everything from an external module" <|
+            \() ->
+                """module A exposing (..)
+import Html exposing (..)
+"""
+                    |> Review.Test.runWithProjectData projectWithHtmlDependencies (rule [])
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Prefer listing what you wish to import and/or using qualified imports"
+                            , details = [ "When you import everything from a module it becomes harder to know where a function or a type comes from." ]
+                            , under = "(..)"
+                            }
+                            |> Review.Test.atExactly { start = { row = 2, column = 22 }, end = { row = 2, column = 26 } }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Html exposing (Attribute, Html, a, abbr, address, article, aside, audio, b, bdi, bdo, blockquote, br, button, canvas, caption, cite, code, col, colgroup, datalist, dd, del, details, dfn, div, dl, dt, em, embed, fieldset, figcaption, figure, footer, form, h1, h2, h3, h4, h5, h6, header, hr, i, iframe, img, input, ins, kbd, label, legend, li, main_, map, mark, math, menu, menuitem, meter, nav, node, object, ol, optgroup, option, output, p, param, pre, progress, q, rp, rt, ruby, s, samp, section, select, small, source, span, strong, sub, summary, sup, table, tbody, td, text, textarea, tfoot, th, thead, time, tr, track, u, ul, var, video, wbr)
+"""
+                        ]
+        , test "when importing everything from an internal module" <|
+            \() ->
+                [ """module Internal.Types exposing (CustomType, MyRecord, Status(..))
+
+type CustomType = Custom
+type alias MyRecord = { name : String }  
+type Status = Active | Inactive
+"""
+                , """module A exposing (..)
+import Internal.Types exposing (..)
+
+value : CustomType
+value = Custom
+"""
+                ]
+                    |> Review.Test.runOnModules (rule [])
+                    |> Review.Test.expectErrorsForModules
+                        [ ( "A"
+                          , [ Review.Test.error
+                                { message = "Prefer listing what you wish to import and/or using qualified imports"
+                                , details = [ "When you import everything from a module it becomes harder to know where a function or a type comes from." ]
+                                , under = "(..)"
+                                }
+                                |> Review.Test.atExactly { start = { row = 2, column = 32 }, end = { row = 2, column = 36 } }
+                                |> Review.Test.whenFixed """module A exposing (..)
+import Internal.Types exposing (CustomType, MyRecord, Status(..))
+
+value : CustomType
+value = Custom
+"""
+                            ]
+                          )
+                        ]
+        , test "when importing everything from an unknown module" <|
+            \() ->
+                """module A exposing (..)
+import UnknownModule exposing (..)
+"""
+                    |> Review.Test.run (rule [])
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Prefer listing what you wish to import and/or using qualified imports"
+                            , details = [ "When you import everything from a module it becomes harder to know where a function or a type comes from." ]
+                            , under = "(..)"
+                            }
+                            |> Review.Test.atExactly { start = { row = 2, column = 31 }, end = { row = 2, column = 35 } }
+                        ]
+        ]
+
+
+projectWithHtmlDependencies : Project
+projectWithHtmlDependencies =
+    Review.Test.Dependencies.projectWithElmCore
+        |> Project.addDependency Review.Test.Dependencies.elmHtml
+
+
+externalModuleFixTests : Test
+externalModuleFixTests =
+    describe "should provide fixes for external modules"
+        [ test "when importing Html" <|
+            \() ->
+                """module A exposing (..)
+import Html exposing (..)
+"""
+                    |> Review.Test.runWithProjectData projectWithHtmlDependencies (rule [])
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Prefer listing what you wish to import and/or using qualified imports"
+                            , details = [ "When you import everything from a module it becomes harder to know where a function or a type comes from." ]
+                            , under = "(..)"
+                            }
+                            |> Review.Test.atExactly { start = { row = 2, column = 22 }, end = { row = 2, column = 26 } }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Html exposing (Attribute, Html, a, abbr, address, article, aside, audio, b, bdi, bdo, blockquote, br, button, canvas, caption, cite, code, col, colgroup, datalist, dd, del, details, dfn, div, dl, dt, em, embed, fieldset, figcaption, figure, footer, form, h1, h2, h3, h4, h5, h6, header, hr, i, iframe, img, input, ins, kbd, label, legend, li, main_, map, mark, math, menu, menuitem, meter, nav, node, object, ol, optgroup, option, output, p, param, pre, progress, q, rp, rt, ruby, s, samp, section, select, small, source, span, strong, sub, summary, sup, table, tbody, td, text, textarea, tfoot, th, thead, time, tr, track, u, ul, var, video, wbr)
+"""
+                        ]
+        , test "when importing Html.Attributes" <|
+            \() ->
+                """module A exposing (..)
+import Html.Attributes exposing (..)
+"""
+                    |> Review.Test.runWithProjectData projectWithHtmlDependencies (rule [])
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Prefer listing what you wish to import and/or using qualified imports"
+                            , details = [ "When you import everything from a module it becomes harder to know where a function or a type comes from." ]
+                            , under = "(..)"
+                            }
+                            |> Review.Test.atExactly { start = { row = 2, column = 33 }, end = { row = 2, column = 37 } }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Html.Attributes exposing (accept, acceptCharset, accesskey, action, align, alt, attribute, autocomplete, autofocus, autoplay, checked, cite, class, classList, cols, colspan, contenteditable, contextmenu, controls, coords, datetime, default, dir, disabled, download, draggable, dropzone, enctype, for, form, headers, height, hidden, href, hreflang, id, ismap, itemprop, kind, lang, list, loop, manifest, map, max, maxlength, media, method, min, minlength, multiple, name, novalidate, pattern, ping, placeholder, poster, preload, property, pubdate, readonly, rel, required, reversed, rows, rowspan, sandbox, scope, selected, shape, size, spellcheck, src, srcdoc, srclang, start, step, style, tabindex, target, title, type_, usemap, value, width, wrap)
+"""
+                        ]
+        , test "should not provide fix for unknown external modules" <|
+            \() ->
+                """module A exposing (..)
+import UnknownModule exposing (..)
+"""
+                    |> Review.Test.run (rule [])
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Prefer listing what you wish to import and/or using qualified imports"
+                            , details = [ "When you import everything from a module it becomes harder to know where a function or a type comes from." ]
+                            , under = "(..)"
+                            }
+                            |> Review.Test.atExactly { start = { row = 2, column = 31 }, end = { row = 2, column = 35 } }
+                        ]
+        ]
+
+
+internalModuleFixTests : Test
+internalModuleFixTests =
+    describe "should provide fixes for internal modules"
+        [ test "when importing from module with explicit exports" <|
+            \() ->
+                [ """module Internal.Types exposing (CustomType, MyRecord, Status(..))
+
+type CustomType = Custom
+type alias MyRecord = { name : String }  
+type Status = Active | Inactive
+"""
+                , """module A exposing (..)
+import Internal.Types exposing (..)
+
+value : CustomType
+value = Custom
+"""
+                ]
+                    |> Review.Test.runOnModules (rule [])
+                    |> Review.Test.expectErrorsForModules
+                        [ ( "A"
+                          , [ Review.Test.error
+                                { message = "Prefer listing what you wish to import and/or using qualified imports"
+                                , details = [ "When you import everything from a module it becomes harder to know where a function or a type comes from." ]
+                                , under = "(..)"
+                                }
+                                |> Review.Test.atExactly { start = { row = 2, column = 32 }, end = { row = 2, column = 36 } }
+                                |> Review.Test.whenFixed """module A exposing (..)
+import Internal.Types exposing (CustomType, MyRecord, Status(..))
+
+value : CustomType
+value = Custom
+"""
+                            ]
+                          )
+                        ]
+        , test "when importing from module with type constructors" <|
+            \() ->
+                [ """module Internal.Data exposing (Result(..), Status, process)
+
+type Result a = Success a | Error String
+type Status = Loading | Complete  
+process : String -> Result String
+process s = Success s
+"""
+                , """module B exposing (..)
+import Internal.Data exposing (..)
+
+handleResult : Result String -> String
+handleResult result =
+    case result of
+        Success s -> s
+        Error e -> e
+"""
+                ]
+                    |> Review.Test.runOnModules (rule [])
+                    |> Review.Test.expectErrorsForModules
+                        [ ( "B"
+                          , [ Review.Test.error
+                                { message = "Prefer listing what you wish to import and/or using qualified imports"
+                                , details = [ "When you import everything from a module it becomes harder to know where a function or a type comes from." ]
+                                , under = "(..)"
+                                }
+                                |> Review.Test.atExactly { start = { row = 2, column = 31 }, end = { row = 2, column = 35 } }
+                                |> Review.Test.whenFixed """module B exposing (..)
+import Internal.Data exposing (Result(..), Status, process)
+
+handleResult : Result String -> String
+handleResult result =
+    case result of
+        Success s -> s
+        Error e -> e
+"""
+                            ]
+                          )
+                        ]
+        ]
+
+
+mixedScenarioTests : Test
+mixedScenarioTests =
+    describe "should handle mixed internal/external scenarios"
+        [ test "when file has both internal and external (..) imports" <|
+            \() ->
+                [ """module Utils.Helper exposing (formatString, parseNumber)
+
+formatString : String -> String
+formatString s = String.trim s
+
+parseNumber : String -> Maybe Int  
+parseNumber s = String.toInt s
+"""
+                , """module Mixed exposing (..)
+import Html exposing (..)
+import Utils.Helper exposing (..)
+
+view : String -> Html msg
+view text = 
+    div [] [ Html.text (formatString text) ]
+"""
+                ]
+                    |> Review.Test.runOnModulesWithProjectData projectWithHtmlDependencies (rule [])
+                    |> Review.Test.expectErrorsForModules
+                        [ ( "Mixed"
+                          , [ Review.Test.error
+                                { message = "Prefer listing what you wish to import and/or using qualified imports"
+                                , details = [ "When you import everything from a module it becomes harder to know where a function or a type comes from." ]
+                                , under = "(..)"
+                                }
+                                |> Review.Test.atExactly { start = { row = 2, column = 22 }, end = { row = 2, column = 26 } }
+                                |> Review.Test.whenFixed """module Mixed exposing (..)
+import Html exposing (Attribute, Html, a, abbr, address, article, aside, audio, b, bdi, bdo, blockquote, br, button, canvas, caption, cite, code, col, colgroup, datalist, dd, del, details, dfn, div, dl, dt, em, embed, fieldset, figcaption, figure, footer, form, h1, h2, h3, h4, h5, h6, header, hr, i, iframe, img, input, ins, kbd, label, legend, li, main_, map, mark, math, menu, menuitem, meter, nav, node, object, ol, optgroup, option, output, p, param, pre, progress, q, rp, rt, ruby, s, samp, section, select, small, source, span, strong, sub, summary, sup, table, tbody, td, text, textarea, tfoot, th, thead, time, tr, track, u, ul, var, video, wbr)
+import Utils.Helper exposing (..)
+
+view : String -> Html msg
+view text = 
+    div [] [ Html.text (formatString text) ]
+"""
+                            , Review.Test.error
+                                { message = "Prefer listing what you wish to import and/or using qualified imports"
+                                , details = [ "When you import everything from a module it becomes harder to know where a function or a type comes from." ]
+                                , under = "(..)"
+                                }
+                                |> Review.Test.atExactly { start = { row = 3, column = 30 }, end = { row = 3, column = 34 } }
+                                |> Review.Test.whenFixed """module Mixed exposing (..)
+import Html exposing (..)
+import Utils.Helper exposing (formatString, parseNumber)
+
+view : String -> Html msg
+view text = 
+    div [] [ Html.text (formatString text) ]
+"""
+                            ]
+                          )
+                        ]
+        ]


### PR DESCRIPTION
This PR adds the functionality requested in https://github.com/jfmengels/elm-review-common/issues/3

```elm
import Foo.Bar exposing (..)
```
When fixed becomes:
```elm
import Foo.Bar exposing (Foo(..), Bar, baz)
```
This could replace the `NoImportingEverything` file, but I'm unsure if there are any standards I need to meet.

I'm looking for feedback and am willing to edit, but the rule works as is.
If it's easier to make edits yourself, that's welcome too. 

I'd love to remove this code from the project that required it.